### PR TITLE
Set 3 rows on iPad

### DIFF
--- a/ImagePickerTrayController/ImagePickerTrayController.swift
+++ b/ImagePickerTrayController/ImagePickerTrayController.swift
@@ -82,7 +82,7 @@ public class ImagePickerTrayController: UIViewController {
         self.height = 216
         
         let numberOfRows = (UIDevice.current.userInterfaceIdiom == .pad) ? 3 : 2
-        let side = round((self.height-2)/CGFloat(numberOfRows))
+        let side = round((self.height-CGFloat(numberOfRows))/CGFloat(numberOfRows))
         self.imageSize = CGSize(width: side, height: side)
         
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
To have 3 rows on iPad, the `height` should be divided by 3, right?